### PR TITLE
Add Octane support

### DIFF
--- a/src/LivewireRelay.php
+++ b/src/LivewireRelay.php
@@ -4,32 +4,27 @@ namespace Masmerise\Toaster;
 
 use Livewire\Component;
 use Livewire\Features\SupportEvents\Event;
-use Livewire\LivewireManager;
-use Livewire\Mechanisms\DataStore;
+use Livewire\Livewire;
 use Livewire\Mechanisms\HandleComponents\ComponentContext;
+
+use function Livewire\store;
 
 /** @internal */
 final readonly class LivewireRelay
 {
     public const EVENT = 'toaster:received';
 
-    public function __construct(
-        private DataStore $store,
-        private LivewireManager $livewire,
-        private Collector $toasts,
-    ) {}
-
     public function __invoke(Component $component, ComponentContext $ctx): void
     {
-        if (! $this->livewire->isLivewireRequest()) {
+        if (! Livewire::isLivewireRequest()) {
             return;
         }
 
-        if ($this->store->get($component, 'redirect')) {
+        if (store($component)->get('redirect')) {
             return;
         }
 
-        if ($toasts = $this->toasts->release()) {
+        if ($toasts = Toaster::release()) {
             foreach ($toasts as $toast) {
                 $event = new Event(self::EVENT, $toast->toArray());
                 $ctx->pushEffect('dispatches', $event->serialize());

--- a/src/ToasterServiceProvider.php
+++ b/src/ToasterServiceProvider.php
@@ -81,7 +81,9 @@ final class ToasterServiceProvider extends AggregateServiceProvider
 
     private function relayToLivewire(): void
     {
-        $this->app[LivewireManager::class]->listen('dehydrate', $this->app[LivewireRelay::class]);
+        $this->app[LivewireManager::class]->listen('dehydrate', function (...$params) {
+            app(LivewireRelay::class)->__invoke(...$params);
+        });
     }
 
     private function relayToSession(): void

--- a/src/ToasterServiceProvider.php
+++ b/src/ToasterServiceProvider.php
@@ -25,10 +25,9 @@ final class ToasterServiceProvider extends AggregateServiceProvider
             $this->registerPublishing();
         }
 
-        $this->relayToSession();
-
         $this->callAfterResolving(BladeCompiler::class, $this->aliasToasterHub(...));
         $this->callAfterResolving(Collector::class, $this->relayToLivewire(...));
+        $this->callAfterResolving(Router::class, $this->relayToSession(...));
 
         Redirector::mixin($macros = new ToastableMacros());
         RedirectResponse::mixin($macros);
@@ -81,14 +80,12 @@ final class ToasterServiceProvider extends AggregateServiceProvider
 
     private function relayToLivewire(): void
     {
-        $this->app[LivewireManager::class]->listen('dehydrate', function (...$params) {
-            app(LivewireRelay::class)->__invoke(...$params);
-        });
+        $this->app[LivewireManager::class]->listen('dehydrate', new LivewireRelay());
     }
 
-    private function relayToSession(): void
+    private function relayToSession(Router $router): void
     {
-        $this->app[Router::class]->aliasMiddleware(SessionRelay::NAME, SessionRelay::class);
-        $this->app[Router::class]->pushMiddlewareToGroup('web', SessionRelay::NAME);
+        $router->aliasMiddleware(SessionRelay::NAME, SessionRelay::class);
+        $router->pushMiddlewareToGroup('web', SessionRelay::NAME);
     }
 }


### PR DESCRIPTION

Laravel version: 10.23
Livewire version: 3.0.5
livewire-toaster version: 2.01
And everything is in AWS Lambdas with Vapor :)


The issue is in ToastServiceProvifder while registering listener of dehydrate event with LivewireRelay. Collector used in Listener is empty. Below I describe why.

From the [laravel doc](https://laravel.com/docs/10.x/octane#dependency-injection-and-octane)

> Since Octane boots your application once and keeps it in memory while serving requests, there are a few caveats you should consider while building your application. For example, the register and boot methods of your application's service providers will only be executed once when the request worker initially boots. On subsequent requests, the same application instance will be reused.

We have registered Collector as singleton in ToasterServiceProvider::register

`$this->app->scoped(Collector::class, QueuingCollector::class);`

And event listener was registered in ToasterServiceProvider::boot
```
    private function relayToLivewire(): void
    {
        $this->app[LivewireManager::class]->listen('dehydrate', $this->app[LivewireRelay::class]);
    }
``` 

And  LivewireRelay has dependencies in constructor, and with that injected instances it would resolve each event.

```
public function __construct(
        private DataStore $store,
        private LivewireManager $livewire,
        private Collector $toasts,
    ) {}
```

So after you load your page first time, `private Collector $toasts` is injected on each following request the **same**  instance first instance. 
However app will boot a new singleton instance of Collector for each request. That is why when livewire update request is called and dehydrate event is triggered our `Collector $toasts->release()` is empty (it uses first bind singleton instance from the first request).

To fix this issue we need to use the same Collector instance on each request. From the Laravel Octane doc 

> As a work-around, you could either stop registering the binding as a singleton, or you could inject a container resolver closure into the service that always resolves the current container instance

And I fix it by adding this in `boot` method  of AppServiceProvider
```
    public function boot(): void
    {
        // your code
        $this->callAfterResolving(Collector::class, $this->relayToLivewire(...));
    }
    

    private function relayToLivewire(): void
    {
        $this->app[LivewireManager::class]->listen('dehydrate', function (...$params) {
            app(LivewireRelay::class)->__invoke(...$params);
        });
    }
```



Thank you guys,
Hope this will help others  too.