### PR TITLE
Fix: Prevent error in toast disposal when $el is null

### DIFF
--- a/resources/js/toast.js
+++ b/resources/js/toast.js
@@ -23,8 +23,10 @@ export class Toast {
 
         this.isVisible = false;
 
-        this.$el.addEventListener('transitioncancel', () => { this.trashed = true; })
-        this.$el.addEventListener('transitionend', () => { this.trashed = true; })
+        if (this.$el) {
+            this.$el.addEventListener('transitioncancel', () => { this.trashed = true; })
+            this.$el.addEventListener('transitionend', () => { this.trashed = true; })
+        }
     }
 
     runAfterDuration(callback) {


### PR DESCRIPTION
In dynamic applications using Livewire, where elements in the DOM can be updated or replaced, calling the `dispose` method on a `Toast` instance sometimes results in an `Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')`. This occurs when `this.$el` is null or undefined, which can happen if the DOM element associated with the Toast has been removed or replaced by Livewire before `dispose` is called.