### PR TITLE
Updated PHP versions in actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        php: ['8.2', '8.3']
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -14,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
           coverage: none
 


### PR DESCRIPTION
Added GH actions for both PHP 8.2 and 8.3 (so you know it works on both versions).
Also updated to the latest checkout actions version.