### PR TITLE
Remove the checking of Livewire component redirects

### DIFF
--- a/src/LivewireRelay.php
+++ b/src/LivewireRelay.php
@@ -20,9 +20,9 @@ final readonly class LivewireRelay
             return;
         }
 
-        if (store($component)->get('redirect')) {
-            return;
-        }
+        // if (store($component)->get('redirect')) {
+        //     return;
+        // }
 
         if ($toasts = Toaster::release()) {
             foreach ($toasts as $toast) {


### PR DESCRIPTION
```php
<?php

namespace App\Livewire;

use Illuminate\Contracts\View\View;
use Livewire\Component;
use Masmerise\Toaster\Toastable;

class Test extends Component
{
    use Toastable;

    public function save()
    {
        // ......

        $this->success('Test Toast Message');

        // This not working when navigate is true.
        $this->redirectRoute('next.route', [
            'hello' => 'world',
        ], navigate: true);
    }

    public function render(): View
    {
        return view('livewire.test');
    }
}
```

I am facing [the](https://github.com/masmerise/livewire-toaster/issues/44) issue, but i found that because you make it return when Livewire component has redirect in `Masmerise\Toaster\LivewireRely` class, may we know the reason that you did it this way?

After I hide the checking logic, it works for me, toast could be displayed after Livewire navigating.