### PR TITLE
Separate the functionality for processing a received toaster event

### DIFF
--- a/resources/js/hub.js
+++ b/resources/js/hub.js
@@ -20,20 +20,21 @@ export function Hub(Alpine) {
 
             init() {
                 document.addEventListener('toaster:received', event => {
-                    const toast = Toast.fromJson({ duration: config.duration, ...event.detail });
-
-                    if (config.replace) {
-                        this.toasts.filter(t => t.equals(toast)).forEach(t => t.dispose());
-                    } else if (config.suppress && this.toasts.some(t => t.equals(toast))) {
-                        return;
-                    }
-
-                    this.show(toast);
+                    this.processToasterEventReceived(event);
                 });
 
                 initialToasts.map(Toast.fromJson).forEach(toast => this.show(toast));
             },
-
+            processToasterEventReceived(event)
+            {
+                const toast = Toast.fromJson({ duration: config.duration, ...event.detail });
+                if (config.replace) {
+                    this.toasts.filter(t => t.equals(toast)).forEach(t => t.dispose());
+                } else if (config.suppress && this.toasts.some(t => t.equals(toast))) {
+                    return;
+                }
+                this.show(toast);
+            },
             show(toast) {
                 toast = Alpine.reactive(toast);
                 toast.runAfterDuration(toast => toast.dispose());

--- a/resources/js/hub.js
+++ b/resources/js/hub.js
@@ -20,21 +20,24 @@ export function Hub(Alpine) {
 
             init() {
                 document.addEventListener('toaster:received', event => {
-                    this.processToasterEventReceived(event);
+                    this.processToast(event);
                 });
 
                 initialToasts.map(Toast.fromJson).forEach(toast => this.show(toast));
             },
-            processToasterEventReceived(event)
-            {
-                const toast = Toast.fromJson({ duration: config.duration, ...event.detail });
+            
+            processToast(data) {
+                const toast = Toast.fromJson({ duration: config.duration, ...data.detail });
+                
                 if (config.replace) {
                     this.toasts.filter(t => t.equals(toast)).forEach(t => t.dispose());
                 } else if (config.suppress && this.toasts.some(t => t.equals(toast))) {
                     return;
                 }
+
                 this.show(toast);
             },
+            
             show(toast) {
                 toast = Alpine.reactive(toast);
                 toast.runAfterDuration(toast => toast.dispose());


### PR DESCRIPTION
This PR is relatively straight forward.

It separates the functionality previously solely defined in the init() function, and creates a new method "processToasterEventReceived" which provides the same functionality.

This method is called by the init() method.

The purpose behind this PR, is to smoothly expose the behaviour for creating a new Toast, so that it is smoother to create Toasts client-side.

The default behaviour of listening only to the document is great, but should a developer wish to listen on a wider basis, there is presently no smooth capability to do so.

This approach allows for use of (for example) the following to capture "window global" events for a "toast"
```
    x-on:send-custom-toast.window="processToasterEventReceived($event)"
```

This does not appear to cause any performance issues upon basic testing.